### PR TITLE
allow memorization of internal lstm state between different forward() calls

### DIFF
--- a/src/layer/lstm.cpp
+++ b/src/layer/lstm.cpp
@@ -68,13 +68,14 @@ int LSTM::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_bl
     int size = input_blob.w;
 
     // initial hidden state
-    Mat hidden(num_output, 4u, opt.workspace_allocator);
+    // created only if necessary by Mat::create
+    hidden.create(num_output, 4u, opt.workspace_allocator);
     if (hidden.empty())
         return -100;
-    hidden.fill(0.f);
 
     // internal cell state
-    Mat cell(num_output, 4u, opt.workspace_allocator);
+    // created only if necessary by Mat::create
+    cell.create(num_output, 4u, opt.workspace_allocator);
     if (cell.empty())
         return -100;
     // 4 x num_output

--- a/src/layer/lstm.h
+++ b/src/layer/lstm.h
@@ -39,6 +39,12 @@ public:
     Mat weight_hc_data;
     Mat weight_xc_data;
     Mat bias_c_data;
+
+    // internal lstm state , mutable so that it can be changed by forward() const
+    // stored here so that successive calls to forward() may restart from previous
+    // state (if unwanted, set cont indicator  to zero at beginning of sequence)
+    mutable Mat hidden;
+    mutable Mat cell;
 };
 
 } // namespace ncnn


### PR DESCRIPTION
this allows to pass timeseries by pieces and have results before the entire timeserie is given to the network